### PR TITLE
Add Symbol polyfill

### DIFF
--- a/polyfills/Symbol/config.json
+++ b/polyfills/Symbol/config.json
@@ -1,0 +1,36 @@
+{
+	"aliases": [
+		"es6",
+		"es2015",
+		"Object.getOwnPropertySymbols",
+		"Symbol.for",
+		"Symbol.keyFor"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "<9",
+		"opera": "< 37",
+		"op_mini": "*",
+		"samsung_mob": "<5",
+		"android": "<5.1",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Array.prototype.forEach",
+		"Array.prototype.filter",
+		"Array.prototype.map",
+		"Object.create",
+		"Object.defineProperty",
+		"Object.getOwnPropertyNames",
+		"Object.getOwnPropertyDescriptor",
+		"Object.freeze",
+		"Object.keys"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol-objects",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/detect.js
+++ b/polyfills/Symbol/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && this.Symbol.length === 0

--- a/polyfills/Symbol/hasInstance/config.json
+++ b/polyfills/Symbol/hasInstance/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.hasinstance",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/hasInstance/detect.js
+++ b/polyfills/Symbol/hasInstance/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'hasInstance' in this.Symbol

--- a/polyfills/Symbol/hasInstance/polyfill.js
+++ b/polyfills/Symbol/hasInstance/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'hasInstance', {value: Symbol('hasInstance')});

--- a/polyfills/Symbol/hasInstance/tests.js
+++ b/polyfills/Symbol/hasInstance/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol hasInstance as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.hasInstance, undefined);
+
+	if (supportsDescriptors) {
+		var hasInstance = Symbol.hasInstance;
+		Symbol.hasInstance = "nope";
+		proclaim.equal(Symbol.hasInstance, hasInstance);
+	}
+});

--- a/polyfills/Symbol/isConcatSpreadable/config.json
+++ b/polyfills/Symbol/isConcatSpreadable/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.isconcatspreadable",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/isConcatSpreadable/detect.js
+++ b/polyfills/Symbol/isConcatSpreadable/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'isConcatSpreadable' in this.Symbol

--- a/polyfills/Symbol/isConcatSpreadable/polyfill.js
+++ b/polyfills/Symbol/isConcatSpreadable/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'isConcatSpreadable', {value: Symbol('isConcatSpreadable')});

--- a/polyfills/Symbol/isConcatSpreadable/tests.js
+++ b/polyfills/Symbol/isConcatSpreadable/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol isConcatSpreadable as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.isConcatSpreadable, undefined);
+
+	if (supportsDescriptors) {
+		var isConcatSpreadable = Symbol.isConcatSpreadable;
+		Symbol.isConcatSpreadable = "nope";
+		proclaim.equal(Symbol.isConcatSpreadable, isConcatSpreadable);
+	}
+});

--- a/polyfills/Symbol/iterator/config.json
+++ b/polyfills/Symbol/iterator/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 9",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "<5.1",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.iterator",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/iterator/detect.js
+++ b/polyfills/Symbol/iterator/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'iterator' in this.Symbol

--- a/polyfills/Symbol/iterator/polyfill.js
+++ b/polyfills/Symbol/iterator/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'iterator', {value: Symbol('iterator')});

--- a/polyfills/Symbol/iterator/tests.js
+++ b/polyfills/Symbol/iterator/tests.js
@@ -1,0 +1,66 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol iterator as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.iterator, undefined);
+
+	if (supportsDescriptors) {
+		var iterator = Symbol.iterator;
+		Symbol.iterator = "nope";
+		proclaim.equal(Symbol.iterator, iterator);
+	}
+});
+
+var hasNodeListGlobal = typeof NodeList !== 'undefined' ? it : xit;
+
+hasNodeListGlobal('can attach to a NodeList correctly', function() {
+
+	NodeList.prototype[Symbol.iterator] = function() {
+		var called = false;
+		var that = this;
+
+		return {
+			next: function() {
+				if (called) {
+					return {
+						done: true
+					};
+				} else {
+					called = true;
+					return {
+						done: false,
+						value: that[0]
+					};
+				}
+			}
+		};
+	};
+	var ul = document.createElement('ul');
+	ul.appendChild(document.createElement('li'));
+
+	var dom = ul.childNodes;
+
+	var iterator = dom[Symbol.iterator]();
+	var entry;
+	while(true) {
+		entry = iterator.next();
+		if (entry.done !== false) break;
+		entry.value.innerHTML = 'Test';
+	}
+
+	proclaim.equal(dom[0].innerHTML, 'Test');
+});

--- a/polyfills/Symbol/match/config.json
+++ b/polyfills/Symbol/match/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.match",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/match/detect.js
+++ b/polyfills/Symbol/match/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'match' in this.Symbol

--- a/polyfills/Symbol/match/polyfill.js
+++ b/polyfills/Symbol/match/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'match', {value: Symbol('match')});

--- a/polyfills/Symbol/match/tests.js
+++ b/polyfills/Symbol/match/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol match as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.match, undefined);
+
+	if (supportsDescriptors) {
+		var match = Symbol.match;
+		Symbol.match = "nope";
+		proclaim.equal(Symbol.match, match);
+	}
+});

--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -1,0 +1,231 @@
+// A modification of https://github.com/WebReflection/get-own-property-symbols
+// (C) Andrea Giammarchi - MIT Licensed
+
+(function (Object, GOPS, global) {
+
+	var	setDescriptor;
+	var id = 0;
+	var random = '' + Math.random();
+	var prefix = '__\x01symbol:';
+	var prefixLength = prefix.length;
+	var internalSymbol = '__\x01symbol@@' + random;
+	var DP = 'defineProperty';
+	var DPies = 'defineProperties';
+	var GOPN = 'getOwnPropertyNames';
+	var GOPD = 'getOwnPropertyDescriptor';
+	var PIE = 'propertyIsEnumerable';
+	var ObjectProto = Object.prototype;
+	var hOP = ObjectProto.hasOwnProperty;
+	var pIE = ObjectProto[PIE];
+	var toString = ObjectProto.toString;
+	var concat = Array.prototype.concat;
+	var cachedWindowNames = typeof window === 'object' ? Object.getOwnPropertyNames(window) : [];
+	var nGOPN = Object[GOPN];
+	var gOPN = function getOwnPropertyNames (obj) {
+		if (toString.call(obj) === '[object Window]') {
+			try {
+				return nGOPN(obj);
+			} catch (e) {
+				// IE bug where layout engine calls userland gOPN for cross-domain `window` objects
+				return concat.call([], cachedWindowNames);
+			}
+		}
+		return nGOPN(obj);
+	};
+	var gOPD = Object[GOPD];
+	var create = Object.create;
+	var keys = Object.keys;
+	var freeze = Object.freeze || Object;
+	var defineProperty = Object[DP];
+	var $defineProperties = Object[DPies];
+	var descriptor = gOPD(Object, GOPN);
+	var addInternalIfNeeded = function (o, uid, enumerable) {
+		if (!hOP.call(o, internalSymbol)) {
+			try {
+				defineProperty(o, internalSymbol, {
+					enumerable: false,
+					configurable: false,
+					writable: false,
+					value: {}
+				});
+			} catch (e) {
+				o[internalSymbol] = {};
+			}
+		}
+		o[internalSymbol]['@@' + uid] = enumerable;
+	};
+	var createWithSymbols = function (proto, descriptors) {
+		var self = create(proto);
+		gOPN(descriptors).forEach(function (key) {
+			if (propertyIsEnumerable.call(descriptors, key)) {
+				$defineProperty(self, key, descriptors[key]);
+			}
+		});
+		return self;
+	};
+	var copyAsNonEnumerable = function (descriptor) {
+		var newDescriptor = create(descriptor);
+		newDescriptor.enumerable = false;
+		return newDescriptor;
+	};
+	var get = function get(){};
+	var onlyNonSymbols = function (name) {
+		return name != internalSymbol &&
+			!hOP.call(source, name);
+	};
+	var onlySymbols = function (name) {
+		return name != internalSymbol &&
+			hOP.call(source, name);
+	};
+	var propertyIsEnumerable = function propertyIsEnumerable(key) {
+		var uid = '' + key;
+		return onlySymbols(uid) ? (
+			hOP.call(this, uid) &&
+			this[internalSymbol]['@@' + uid]
+		) : pIE.call(this, key);
+	};
+	var setAndGetSymbol = function (uid) {
+		var descriptor = {
+			enumerable: false,
+			configurable: true,
+			get: get,
+			set: function (value) {
+			setDescriptor(this, uid, {
+				enumerable: false,
+				configurable: true,
+				writable: true,
+				value: value
+			});
+			addInternalIfNeeded(this, uid, true);
+			}
+		};
+		try {
+			defineProperty(ObjectProto, uid, descriptor);
+		} catch (e) {
+			ObjectProto[uid] = descriptor.value;
+		}
+		return freeze(source[uid] = defineProperty(
+			Object(uid),
+			'constructor',
+			sourceConstructor
+		));
+	};
+	var Symbol = function Symbol() {
+		var description = arguments[0];
+		if (this instanceof Symbol) {
+			throw new TypeError('Symbol is not a constructor');
+		}
+		return setAndGetSymbol(
+			prefix.concat(description || '', random, ++id)
+		);
+		};
+	var source = create(null);
+	var sourceConstructor = {value: Symbol};
+	var sourceMap = function (uid) {
+		return source[uid];
+		};
+	var $defineProperty = function defineProp(o, key, descriptor) {
+		var uid = '' + key;
+		if (onlySymbols(uid)) {
+			setDescriptor(o, uid, descriptor.enumerable ?
+				copyAsNonEnumerable(descriptor) : descriptor);
+			addInternalIfNeeded(o, uid, !!descriptor.enumerable);
+		} else {
+			defineProperty(o, key, descriptor);
+		}
+		return o;
+	};
+
+	var onlyInternalSymbols = function (obj) {
+		return function (name) {
+			return hOP.call(obj, internalSymbol) && hOP.call(obj[internalSymbol], '@@' + name);
+		};
+	};
+	var $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+		return gOPN(o).filter(o === ObjectProto ? onlyInternalSymbols(o) : onlySymbols).map(sourceMap);
+		}
+	;
+
+	descriptor.value = $defineProperty;
+	defineProperty(Object, DP, descriptor);
+
+	descriptor.value = $getOwnPropertySymbols;
+	defineProperty(Object, GOPS, descriptor);
+
+	descriptor.value = function getOwnPropertyNames(o) {
+		return gOPN(o).filter(onlyNonSymbols);
+	};
+	defineProperty(Object, GOPN, descriptor);
+
+	descriptor.value = function defineProperties(o, descriptors) {
+		var symbols = $getOwnPropertySymbols(descriptors);
+		if (symbols.length) {
+		keys(descriptors).concat(symbols).forEach(function (uid) {
+			if (propertyIsEnumerable.call(descriptors, uid)) {
+			$defineProperty(o, uid, descriptors[uid]);
+			}
+		});
+		} else {
+		$defineProperties(o, descriptors);
+		}
+		return o;
+	};
+	defineProperty(Object, DPies, descriptor);
+
+	descriptor.value = propertyIsEnumerable;
+	defineProperty(ObjectProto, PIE, descriptor);
+
+	descriptor.value = Symbol;
+	defineProperty(global, 'Symbol', descriptor);
+
+	// defining `Symbol.for(key)`
+	descriptor.value = function (key) {
+		var uid = prefix.concat(prefix, key, random);
+		return uid in ObjectProto ? source[uid] : setAndGetSymbol(uid);
+	};
+	defineProperty(Symbol, 'for', descriptor);
+
+	// defining `Symbol.keyFor(symbol)`
+	descriptor.value = function (symbol) {
+		if (onlyNonSymbols(symbol))
+		throw new TypeError(symbol + ' is not a symbol');
+		return hOP.call(source, symbol) ?
+		symbol.slice(prefixLength * 2, -random.length) :
+		void 0
+		;
+	};
+	defineProperty(Symbol, 'keyFor', descriptor);
+
+	descriptor.value = function getOwnPropertyDescriptor(o, key) {
+		var descriptor = gOPD(o, key);
+		if (descriptor && onlySymbols(key)) {
+		descriptor.enumerable = propertyIsEnumerable.call(o, key);
+		}
+		return descriptor;
+	};
+	defineProperty(Object, GOPD, descriptor);
+
+	descriptor.value = function (proto, descriptors) {
+		return arguments.length === 1 || typeof descriptors === "undefined" ?
+		create(proto) :
+		createWithSymbols(proto, descriptors);
+	};
+	defineProperty(Object, 'create', descriptor);
+
+	descriptor.value = function () {
+		var str = toString.call(this);
+		return (str === '[object String]' && onlySymbols(this)) ? '[object Symbol]' : str;
+	};
+	defineProperty(ObjectProto, 'toString', descriptor);
+
+
+	setDescriptor = function (o, key, descriptor) {
+		var protoDescriptor = gOPD(ObjectProto, key);
+		delete ObjectProto[key];
+		defineProperty(o, key, descriptor);
+		if (o !== ObjectProto) {
+			defineProperty(ObjectProto, key, protoDescriptor);
+		}
+	};
+
+}(Object, 'getOwnPropertySymbols', this));

--- a/polyfills/Symbol/replace/config.json
+++ b/polyfills/Symbol/replace/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.replace",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/replace/detect.js
+++ b/polyfills/Symbol/replace/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'replace' in this.Symbol

--- a/polyfills/Symbol/replace/polyfill.js
+++ b/polyfills/Symbol/replace/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'replace', {value: Symbol('replace')});

--- a/polyfills/Symbol/replace/tests.js
+++ b/polyfills/Symbol/replace/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol replace as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.replace, undefined);
+
+	if (supportsDescriptors) {
+		var replace = Symbol.replace;
+		Symbol.replace = "nope";
+		proclaim.equal(Symbol.replace, replace);
+	}
+});

--- a/polyfills/Symbol/search/config.json
+++ b/polyfills/Symbol/search/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.search",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/search/detect.js
+++ b/polyfills/Symbol/search/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'search' in this.Symbol

--- a/polyfills/Symbol/search/polyfill.js
+++ b/polyfills/Symbol/search/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'search', {value: Symbol('search')});

--- a/polyfills/Symbol/search/tests.js
+++ b/polyfills/Symbol/search/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol search as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.search, undefined);
+
+	if (supportsDescriptors) {
+		var search = Symbol.search;
+		Symbol.search = "nope";
+		proclaim.equal(Symbol.search, search);
+	}
+});

--- a/polyfills/Symbol/species/config.json
+++ b/polyfills/Symbol/species/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "<10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.species",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/species/detect.js
+++ b/polyfills/Symbol/species/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'species' in this.Symbol

--- a/polyfills/Symbol/species/polyfill.js
+++ b/polyfills/Symbol/species/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'species', {value: Symbol('species')});

--- a/polyfills/Symbol/species/tests.js
+++ b/polyfills/Symbol/species/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol species as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.species, undefined);
+
+	if (supportsDescriptors) {
+		var species = Symbol.species;
+		Symbol.species = "nope";
+		proclaim.equal(Symbol.species, species);
+	}
+});

--- a/polyfills/Symbol/split/config.json
+++ b/polyfills/Symbol/split/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.split",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/split/detect.js
+++ b/polyfills/Symbol/split/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'split' in this.Symbol

--- a/polyfills/Symbol/split/polyfill.js
+++ b/polyfills/Symbol/split/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'split', {value: Symbol('split')});

--- a/polyfills/Symbol/split/tests.js
+++ b/polyfills/Symbol/split/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol split as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.split, undefined);
+
+	if (supportsDescriptors) {
+		var split = Symbol.split;
+		Symbol.split = "nope";
+		proclaim.equal(Symbol.split, split);
+	}
+});

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -1,0 +1,222 @@
+/* eslint-env mocha */
+/* globals proclaim, Symbol */
+
+it('is a function', function () {
+	proclaim.isFunction(Symbol);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Symbol, 0);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Symbol, 'Symbol');
+});
+
+it('is not enumerable', function () {
+	proclaim.nonEnumerable(window, 'Symbol');
+});
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+// https://tc39.github.io/ecma262/#sec-symbol-constructor
+it('should throw if being used via `new`', function() {
+	var test = function () {
+		return new Symbol();
+	};
+	proclaim.throws(test);
+});
+
+it('should have Symbol as the constructor property', function() {
+	proclaim.equal(Symbol().constructor, Symbol);
+});
+
+xit('should silently fail when assigning new properties', function (){
+	var a = Symbol("1");
+	a.b = '1';
+	proclaim.equal(a.b, undefined);
+});
+
+// A tough one right now
+xit('should have Symbol.prototype as the prototype of an instance', function() {
+	proclaim.equal(Object.getPrototypeOf(Symbol()), Symbol.prototype);
+});
+
+it('should return "[object Symbol]" when called with Object.prototype.toString()', function() {
+	proclaim.equal(Object.prototype.toString.call(Symbol()), '[object Symbol]');
+});
+
+if (supportsDescriptors) {
+	it('should silently fail when overwriting properties', function() {
+		var sym = Symbol("2");
+		sym.toString = 0;
+		proclaim.isInstanceOf(sym.toString, Function);
+		sym.valueOf = 0;
+		proclaim.isInstanceOf(sym.valueOf, Function);
+	});
+}
+
+it('should create unique symbols', function() {
+	proclaim.notEqual(Symbol("3"), Symbol("3"));
+});
+
+it('has for, and keyFor static methods', function() {
+	proclaim.isInstanceOf(Symbol["for"], Function);
+	proclaim.isInstanceOf(Symbol.keyFor, Function);
+});
+
+it('Symbol.keyFor should throw if not given a symbol', function() {
+	var stringKeyFor = function() {
+		return Symbol.keyFor('a');
+	};
+	var numberKeyFor = function() {
+		return Symbol.keyFor(1);
+	};
+	var arrayKeyFor = function() {
+		return Symbol.keyFor([]);
+	};
+	var objectKeyFor = function() {
+		return Symbol.keyFor({});
+	};
+	var boolKeyFor = function() {
+		return Symbol.keyFor(true);
+	};
+	var undefinedKeyFor = function() {
+		return Symbol.keyFor(undefined);
+	};
+	var symbolKeyFor = function() {
+		return Symbol.keyFor(Symbol("4"));
+	};
+
+	proclaim.throws(stringKeyFor);
+	proclaim.throws(numberKeyFor);
+	proclaim.throws(arrayKeyFor);
+	proclaim.throws(objectKeyFor);
+	proclaim.throws(boolKeyFor);
+	proclaim.throws(undefinedKeyFor);
+	proclaim.doesNotThrow(symbolKeyFor);
+});
+
+xit('Symbol.keyFor should return undefined if can not find symbol in global registry', function() {
+	proclaim.equal(Symbol.keyFor(Symbol("5")), undefined);
+});
+
+xit('Symbol() should not add the symbol to the global registry', function() {
+	var sym = Symbol("6");
+	proclaim.equal(Symbol.keyFor(sym), undefined);
+});
+
+it('Symbol["for"] should create new symbol if can not find symbol in global registry', function() {
+	var sym1 = Symbol("7");
+	var sym2 = Symbol["for"]("7");
+	proclaim.notEqual(sym1, sym2);
+});
+
+it('Symbol["for"] should return symbol if can find symbol in global registry', function() {
+	var sym = Symbol["for"]("8");
+	proclaim.equal(sym, Symbol["for"]("8"));
+});
+
+it('Symbol.keyFor should return key of symbol if can find symbol in global registry', function() {
+	var key = "9";
+	var sym = Symbol["for"](key);
+	proclaim.equal(Symbol.keyFor(sym), key);
+});
+
+it('has toString and valueOf instance methods', function() {
+	proclaim.isInstanceOf(Symbol.prototype['toString'], Function);
+	proclaim.isInstanceOf(Symbol.prototype['valueOf'], Function);
+});
+
+if (supportsDescriptors) {
+	// https://kangax.github.io/compat-table/es6/#Symbol_symbol_keys_are_hidden_to_pre-ES6_code
+	it('should make symbols non-enumerable', function() {
+		var object = {};
+		var symbol = Symbol();
+		object[symbol] = 1;
+
+		for (var x in object){}
+		var passed = !x;
+
+		proclaim.equal(passed, true);
+		proclaim.equal(Object.keys(object).length, 0);
+		proclaim.equal(Object.getOwnPropertyNames(object).length, 0);
+		proclaim.equal(Object.prototype.propertyIsEnumerable.call(object, symbol), true);
+	});
+
+	it('should return false from propertyIsEnumerable for symbols defined non-enumerable', function() {
+		var object = {};
+		var symbol = Symbol();
+		Object.defineProperty(object, symbol, { enumerable: false });
+
+		for (var x in object){}
+		var passed = !x;
+
+		proclaim.equal(passed, true);
+		proclaim.equal(Object.keys(object).length, 0);
+		proclaim.equal(Object.getOwnPropertyNames(object).length, 0);
+		proclaim.equal(Object.prototype.propertyIsEnumerable.call(object, symbol), false);
+	});
+
+	it('should not fail on propertyIsEnumerable for deep clones', function() {
+		// See: https://github.com/Financial-Times/polyfill-service/issues/1058
+		var symbol0 = Symbol();
+		var symbol1 = Symbol();
+
+		proclaim.equal(Object.getOwnPropertySymbols(Object.prototype).length, 0);
+		Object.prototype[symbol0] = 'Symbol(0)';
+		proclaim.equal(Object.getOwnPropertySymbols(Object.prototype).length, 1);
+		Object.defineProperty(Object.prototype, symbol1, { value: 'Symbol(1)'});
+		proclaim.equal(Object.getOwnPropertySymbols(Object.prototype).length, 2);
+	});
+}
+
+// Not really possible on a polyfill
+xit('should perform correctly with toString operations', function() {
+	proclaim.equal(String(Symbol('10')), 'Symbol(10)');
+	proclaim.equal(Symbol('10').toString(), 'Symbol(10)');
+	proclaim.equal(Object(Symbol('10')).toString(), 'Symbol(10)');
+	proclaim.equal(Symbol.prototype.toString.call(Symbol('10')), 'Symbol(10)');
+});
+
+// Not really possible on a polyfill
+xit('should not allow implicit string coercion', function() {
+	var implicitStringCoercion = function() {
+		return Symbol('10') + '';
+	};
+	proclaim.throws(implicitStringCoercion);
+});
+
+it('should create Object without symbols', function () {
+	var Obj = function () {};
+	var obj = Object.create(Obj.prototype);
+	proclaim.equal(obj instanceof Obj, true);
+});
+
+it('should create Object without symbols, second argument undefined', function () {
+	var Obj = function () {};
+	var obj = Object.create(Obj.prototype, undefined);
+	proclaim.equal(obj instanceof Obj, true);
+});
+
+it('does not break when an iframe is added', function () {
+	var div = document.createElement('div');
+	div.innerHTML = '<iframe src="https://xkcd.com"></iframe>';
+	document.body.appendChild(div);
+	setTimeout(function () {
+		document.body.removeChild(div);
+	}, 0);
+	proclaim.equal(Object.prototype.toString.call(Object.getOwnPropertyNames(window)) === '[object Array]', true);
+});

--- a/polyfills/Symbol/toPrimitive/config.json
+++ b/polyfills/Symbol/toPrimitive/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.toprimitive",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/toPrimitive/detect.js
+++ b/polyfills/Symbol/toPrimitive/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'toPrimitive' in this.Symbol

--- a/polyfills/Symbol/toPrimitive/polyfill.js
+++ b/polyfills/Symbol/toPrimitive/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'toPrimitive', {value: Symbol('toPrimitive')});

--- a/polyfills/Symbol/toPrimitive/tests.js
+++ b/polyfills/Symbol/toPrimitive/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol toPrimitive as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.toPrimitive, undefined);
+
+	if (supportsDescriptors) {
+		var toPrimitive = Symbol.toPrimitive;
+		Symbol.toPrimitive = "nope";
+		proclaim.equal(Symbol.toPrimitive, toPrimitive);
+	}
+});

--- a/polyfills/Symbol/toStringTag/config.json
+++ b/polyfills/Symbol/toStringTag/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 10",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.tostringtag",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/toStringTag/detect.js
+++ b/polyfills/Symbol/toStringTag/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'toStringTag' in this.Symbol

--- a/polyfills/Symbol/toStringTag/polyfill.js
+++ b/polyfills/Symbol/toStringTag/polyfill.js
@@ -1,0 +1,3 @@
+Object.defineProperty(Symbol, 'toStringTag', {
+	value: Symbol('toStringTag')
+});

--- a/polyfills/Symbol/toStringTag/tests.js
+++ b/polyfills/Symbol/toStringTag/tests.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol toStringTag as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.toStringTag, undefined);
+
+	if (supportsDescriptors) {
+		var toStringTag = Symbol.toStringTag;
+		Symbol.toStringTag = "nope";
+		proclaim.equal(Symbol.toStringTag, toStringTag);
+	}
+});

--- a/polyfills/Symbol/unscopables/config.json
+++ b/polyfills/Symbol/unscopables/config.json
@@ -1,0 +1,25 @@
+{
+	"aliases": [
+		"es6",
+		"es2015"
+	],
+	"browsers": {
+		"ie": "< 13",
+		"ie_mob": "*",
+		"safari": "<9",
+		"chrome": "< 50",
+		"firefox": "< 40",
+		"ios_saf": "< 9",
+		"opera": "< 37",
+		"samsung_mob": "<5",
+		"android": "*",
+		"bb": "10 - *"
+	},
+	"dependencies": [
+		"Object.defineProperty",
+		"Symbol"
+	],
+	"license": "MIT",
+	"spec": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol.unscopables",
+	"docs": "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol"
+}

--- a/polyfills/Symbol/unscopables/detect.js
+++ b/polyfills/Symbol/unscopables/detect.js
@@ -1,0 +1,1 @@
+'Symbol' in this && 'unscopables' in this.Symbol

--- a/polyfills/Symbol/unscopables/polyfill.js
+++ b/polyfills/Symbol/unscopables/polyfill.js
@@ -1,0 +1,1 @@
+Object.defineProperty(Symbol, 'unscopables', {value: Symbol('unscopables')});

--- a/polyfills/Symbol/unscopables/tests.js
+++ b/polyfills/Symbol/unscopables/tests.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (var _ in obj) { return false; }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
+	} catch (e) { // this is IE 8.
+		return false;
+	}
+};
+var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
+
+it('has the well known symbol unscopables as static properties on Symbol', function() {
+	proclaim.notEqual(Symbol.unscopables, undefined);
+	if (supportsDescriptors) {
+		var unscopables = Symbol.unscopables;
+		Symbol.unscopables = "nope";
+		proclaim.equal(Symbol.unscopables, unscopables);
+	}
+});


### PR DESCRIPTION
## What
- copy over `Symbol` polyfill from [/Financial-Times/polyfill-service](https://github.com/Financial-Times/polyfill-service)

## Why
IE browsers older than v12 don't support `Symbol`. 